### PR TITLE
Updating backward_rosConfig.cmake.in for Windows

### DIFF
--- a/backward_rosConfig.cmake.in
+++ b/backward_rosConfig.cmake.in
@@ -1,4 +1,8 @@
 @PACKAGE_INIT@
 set_and_check(backward_ros_INCLUDE_DIRS "@BACKWARD_ROS_INSTALL_PREFIX@/include")
+if(WIN32)
 set_and_check(backward_ros_LIBRARIES "@BACKWARD_ROS_INSTALL_PREFIX@/lib/backward.lib")
+else()
+set_and_check(backward_ros_LIBRARIES "@BACKWARD_ROS_INSTALL_PREFIX@/lib/libbackward.so")
+endif()
 check_required_components(backward_ros)

--- a/backward_rosConfig.cmake.in
+++ b/backward_rosConfig.cmake.in
@@ -1,4 +1,4 @@
 @PACKAGE_INIT@
 set_and_check(backward_ros_INCLUDE_DIRS "@BACKWARD_ROS_INSTALL_PREFIX@/include")
-set_and_check(backward_ros_LIBRARIES "@BACKWARD_ROS_INSTALL_PREFIX@/lib/libbackward.so")
+set_and_check(backward_ros_LIBRARIES "@BACKWARD_ROS_INSTALL_PREFIX@/lib/backward.lib")
 check_required_components(backward_ros)


### PR DESCRIPTION
This pull request introduces changes to the CMake configuration to ensure cross-platform compatibility for the backward_ros_LIBRARIES variable, indicated here: #19 

Thank you!