### PR TITLE
Make backward_rosConfig.cmake file relocatable

### DIFF
--- a/backward_rosConfig.cmake.in
+++ b/backward_rosConfig.cmake.in
@@ -1,9 +1,9 @@
 @PACKAGE_INIT@
-set_and_check(backward_ros_INCLUDE_DIRS "@BACKWARD_ROS_INSTALL_PREFIX@/include")
+set_and_check(backward_ros_INCLUDE_DIRS "@PACKAGE_BACKWARD_ROS_INSTALL_PREFIX@/include")
 if(WIN32)
-set_and_check(backward_ros_LIBRARIES "@BACKWARD_ROS_INSTALL_PREFIX@/lib/backward.lib")
+set_and_check(backward_ros_LIBRARIES "@PACKAGE_BACKWARD_ROS_INSTALL_PREFIX@/lib/backward.lib")
 else()
-set_and_check(backward_ros_LIBRARIES "@BACKWARD_ROS_INSTALL_PREFIX@/lib/libbackward.so")
+set_and_check(backward_ros_LIBRARIES "@PACKAGE_BACKWARD_ROS_INSTALL_PREFIX@/lib/libbackward.so")
 endif()
 check_required_components(backward_ros)
-include(@BACKWARD_ROS_INSTALL_PREFIX@/share/@PROJECT_NAME@/cmake/BackwardConfigAment.cmake)
+include(@PACKAGE_BACKWARD_ROS_INSTALL_PREFIX@/share/@PROJECT_NAME@/cmake/BackwardConfigAment.cmake)


### PR DESCRIPTION
First of all, thanks a lot for working on this package.

While working on packaging this package for robostack in https://github.com/RoboStack/ros-humble/pull/229#issuecomment-2567039092, I noticed that the `backward_rosConfig.cmake` file generated by this package was not relocatable (see https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#creating-relocatable-packages for reference on relocatable packages).

In particular, the `BACKWARD_ROS_INSTALL_PREFIX` variable was correctly passed via the `configure_package_config_file`'s `PATH_VARS` argument in https://github.com/pal-robotics/backward_ros/blob/6ca0607b3cf1fed6f79ed3e2b4f9324ffc4a5f5c/CMakeLists.txt#L126, but then it was used directly in the template file, and this is wrong as according to the `configure_package_config_file` documentation at https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html :

> Instead of set(FOO_DIR "@SOME_INSTALL_DIR@"), use set(FOO_DIR "@PACKAGE_SOME_INSTALL_DIR@") (this must be after the @PACKAGE_INIT@ line).

> The variables <var1> to <varN> given as PATH_VARS are the variables which contain install destinations. For each of them, the macro will create a helper variable PACKAGE_<var...>. These helper variables must be used in the FooConfig.cmake.in file for setting the installed location. They are calculated by configure_package_config_file() so that they are always relative to the installed location of the package. This works both for relative and also for absolute locations. For absolute locations, it works only if the absolute location is a subdirectory of INSTALL_PREFIX.

Adding the `PACKAGE_` prefix in the template ensure that the generated cmake config file is indeed relocatable.

