### PR TITLE
Install the package.xml as well, it is needed for the ros debian pack…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,10 @@ install(DIRECTORY cmake
         DESTINATION share/${PROJECT_NAME}
 )
 
+install(FILES package.xml
+        DESTINATION share/${PROJECT_NAME}
+)
+
 include(CMakePackageConfigHelpers)
 set(BACKWARD_ROS_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}" CACHE PATH "backward_ros install prefix")
 configure_package_config_file(


### PR DESCRIPTION
I am using the Humble version of `backward_ros` in a project and I appreciate your support.

I read metadata of ROS packages using the [rospkg](https://docs.ros.org/en/independent/api/rospkg/html/rospkg_packages.html) module. It was working fine with the Galactic version (1.0.3) but I encountered issues with the Humble version (1.0.6).

Upon investigation, I found that the `package.xml` file is no longer being installed in the `/opt/ros/humble/share/backward_ros` directory. This file is required for ROS packages to read metadata, such as license information.

It looks like, it was happened after switching to pure CMake.

This PR reinstalls the `package.xml` file, and I have tested it to confirm that it resolves the problem.