### PR TITLE
Fix include path exported by BackwardConfig.cmake

### DIFF
--- a/cmake/BackwardConfig.cmake
+++ b/cmake/BackwardConfig.cmake
@@ -123,7 +123,7 @@ foreach(def ${BACKWARD_DEFINITIONS})
 	message(STATUS "${def}")
 endforeach()
 
-set(BACKWARD_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+set(BACKWARD_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../include/backward_ros")
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Backward


### PR DESCRIPTION
I ran into the following issue when trying to include `backward.hpp` installed from this library:
In the `Backward::Backward` target, the include path (exported through `INTERFACE_INCLUDE_DIRECTORIES`) was set to the directory that contains `BackwardConfig.cmake` (`xxx/share/backward_ros/cmake`) rather than the one that contains `backward.hpp` (`xxx/include/backward_ros`).
This MR changes the include path to point to the correct directory.

In my case this fixed the issue and I think it makes sense to include this change in general or let me know if I'm missing something here.