### PR TITLE
BackwardConfigAment: Only use --as-needed on ELF platforms

### DIFF
--- a/cmake/BackwardConfigAment.cmake
+++ b/cmake/BackwardConfigAment.cmake
@@ -24,5 +24,14 @@ foreach(lib ${backward_ros_forced_LIBRARIES})
         set(backward_ros_full_path_LIBRARIES "${backward_ros_full_path_LIBRARIES} ${lib}")
     endif()
 endforeach()
-SET(CMAKE_EXE_LINKER_FLAGS "-Wl,--no-as-needed ${backward_ros_full_path_LIBRARIES} -Wl,--as-needed ${CMAKE_EXE_LINKER_FLAGS}")
 
+# --no-as-needed and --as-needed only make sense on ELF platforms, so let's try to only set there
+set(no_as_needed)
+set(as_needed)
+# CMake does not provide any way to directly check if platform is ELF, but UNIX AND NOT APPLE should work fine at
+# least in ROS context
+if(UNIX AND NOT APPLE)
+    set(no_as_needed "-Wl,--no-as-needed")
+    set(as_needed "-Wl,--as-needed")
+endif()
+SET(CMAKE_EXE_LINKER_FLAGS "${no_as_needed} ${backward_ros_full_path_LIBRARIES} ${as_needed} ${CMAKE_EXE_LINKER_FLAGS}")


### PR DESCRIPTION
`--no-as-needed` and `--as-needed` only make sense on ELF platforms (i.e. Linux and not macOS or Windows), so this PR tries to only pass them to the linked in that case.