### PR TITLE
Add loongarch64 support

### DIFF
--- a/include/backward_ros/backward.hpp
+++ b/include/backward_ros/backward.hpp
@@ -4220,6 +4220,8 @@ public:
     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.__gregs[REG_PC]);
 #elif defined(__s390x__)
     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.psw.addr);
+#elif defined(__loongarch64)
+    error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.__pc);
 #elif defined(__APPLE__) && defined(__x86_64__)
     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext->__ss.__rip);
 #elif defined(__APPLE__)


### PR DESCRIPTION
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.
Documentations:
ISA:
https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
ABI:
https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
More docs can be found at:
https://loongson.github.io/LoongArch-Documentation/README-EN.html