### PR TITLE
Make exported CMake config cross-platform (non-GNU linkers, header-only)

### DIFF
--- a/cmake/BackwardConfig.cmake
+++ b/cmake/BackwardConfig.cmake
@@ -125,11 +125,18 @@ endforeach()
 
 set(BACKWARD_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
+# BACKWARD_LIBRARIES can legitimately be empty (e.g. a header-only
+# configuration where no stack-walking backend library was found). Only
+# require it when it is actually set, so that find_package(Backward) still
+# succeeds in that case.
+set(FIND_PACKAGE_REQUIRED_VARS BACKWARD_INCLUDE_DIR)
+if(DEFINED BACKWARD_LIBRARIES)
+    list(APPEND FIND_PACKAGE_REQUIRED_VARS BACKWARD_LIBRARIES)
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Backward
-    REQUIRED_VARS
-        BACKWARD_INCLUDE_DIR
-        BACKWARD_LIBRARIES
+    REQUIRED_VARS ${FIND_PACKAGE_REQUIRED_VARS}
 )
 list(APPEND _BACKWARD_INCLUDE_DIRS ${BACKWARD_INCLUDE_DIR})
 

--- a/cmake/BackwardConfigAment.cmake
+++ b/cmake/BackwardConfigAment.cmake
@@ -24,5 +24,16 @@ foreach(lib ${backward_ros_forced_LIBRARIES})
         set(backward_ros_full_path_LIBRARIES "${backward_ros_full_path_LIBRARIES} ${lib}")
     endif()
 endforeach()
-SET(CMAKE_EXE_LINKER_FLAGS "-Wl,--no-as-needed ${backward_ros_full_path_LIBRARIES} -Wl,--as-needed ${CMAKE_EXE_LINKER_FLAGS}")
+# The --no-as-needed/--as-needed flags are specific to the GNU/binutils
+# linker. Other linkers (e.g. AppleClang's ld64 on macOS, or MSVC) do not
+# understand them and would fail. Only emit them for the GNU toolchain.
+set(no_as_needed)
+set(as_needed)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(no_as_needed "-Wl,--no-as-needed")
+    set(as_needed "-Wl,--as-needed")
+endif()
+
+SET(CMAKE_EXE_LINKER_FLAGS "${no_as_needed} ${backward_ros_full_path_LIBRARIES} ${as_needed} ${CMAKE_EXE_LINKER_FLAGS}")
 


### PR DESCRIPTION
While packaging `backward_ros` for [RoboStack](https://github.com/RoboStack) (conda packages of ROS, built on Linux, macOS and Windows), we carry two small local patches to the exported CMake config. Both are general portability fixes, so I'd like to upstream them.

### 1. Guard GNU-only linker flags (`BackwardConfigAment.cmake`)

`CMAKE_EXE_LINKER_FLAGS` is set with `-Wl,--no-as-needed ... -Wl,--as-needed`. Those flags are specific to the GNU/binutils linker. They are not understood by AppleClang's `ld64` on macOS, nor by MSVC, and cause link failures there. This change only emits them when `CMAKE_CXX_COMPILER_ID` is `GNU`.

### 2. Don't hard-require `BACKWARD_LIBRARIES` (`BackwardConfig.cmake`)

`find_package_handle_standard_args(Backward REQUIRED_VARS ... BACKWARD_LIBRARIES)` fails when `BACKWARD_LIBRARIES` is empty — which is a legitimate header-only configuration (no stack-walking backend library found). This makes that var conditional so `find_package(Backward)` still succeeds in that case.

Both changes are no-ops for the existing GNU/Linux path. Happy to adjust naming or split into two PRs if you prefer.